### PR TITLE
Bug: Fixes Rmd for vignette building

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))


### PR DESCRIPTION
This PR adds Pandoc support the the GitHub action allowing for vignettes to be built (cause of current failure in the action)