### PR TITLE
Fix notes

### DIFF
--- a/R/load_mappings.R
+++ b/R/load_mappings.R
@@ -35,7 +35,7 @@ load_mapping <- function(scale, source) {
   }
   
   # Return mapping
-  out <- covid19.nhs.data:::mappings %>%
+  out <- mappings %>%
     filter(map_source == source,
            map_level == scale) %>%
     select(-c(map_source, map_level))

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,9 +12,7 @@ NULL
 
 globalVariables(
   c(
-    "admissions", "data", "ltla_code", "org_code", "p", "p_trust", "p_utla",
-    "trust_code", "trust_ltla_mapping", "trust_name", "trust_names",
-    "trust_utla_mapping", "type1_acute", "geo_code", "geo_name", "geo_names",
-    "england_utla_shape", "value", "p_geo", "utla_names"
+    "data", "geo_code", "geo_name", "map_level", "map_source", "new_adm", "nhs_region",
+    "org_code", "p", "p_geo", "p_trust", "trust_code", "trust_name", "value", "var", "var_name"
   )
 )


### PR DESCRIPTION
Very exciting PR fixing 2 notes flagged in `devtools::check()`:

There are ::: calls to the package's namespace in its code. A package almost never needs to use ::: for its own objects: ‘mappings’

download_trust_data: no visible binding for global variable ‘data’
download_trust_data: no visible binding for global variable ‘nhs_region’
download_trust_data: no visible binding for global variable ‘org_code’
get_admissions: no visible binding for global variable ‘var_name’
get_admissions: no visible binding for global variable ‘data’
get_admissions: no visible binding for global variable ‘org_code’
get_admissions: no visible binding for global variable ‘value’
get_admissions: no visible binding for global variable ‘trust_code’
get_admissions: no visible binding for global variable ‘trust_name’
get_admissions: no visible binding for global variable ‘var’
get_admissions: no visible binding for global variable ‘p_trust’
get_admissions: no visible binding for global variable ‘geo_code’
get_admissions: no visible binding for global variable ‘geo_name’
get_admissions: no visible binding for global variable ‘new_adm’
get_names: no visible binding for global variable ‘trust_code’
get_names: no visible binding for global variable ‘trust_name’
get_names: no visible binding for global variable ‘geo_code’
get_names: no visible binding for global variable ‘geo_name’
get_names: no visible binding for global variable ‘p_trust’
get_names: no visible binding for global variable ‘p_geo’
load_mapping: no visible binding for global variable ‘map_source’
load_mapping: no visible binding for global variable ‘map_level’
summarise_mapping: no visible binding for global variable ‘trust_code’
summarise_mapping: no visible binding for global variable ‘trust_name’
summarise_mapping: no visible binding for global variable ‘geo_code’
summarise_mapping: no visible binding for global variable ‘geo_name’
summarise_mapping: no visible binding for global variable ‘p_trust’
summarise_mapping: no visible binding for global variable ‘p’
summarise_mapping: no visible binding for global variable ‘p_geo’
Undefined global functions or variables: data geo_code geo_name map_level map_source new_adm nhs_region org_code p p_geo p_trust trust_code trust_name value var var_name
Consider adding importFrom("stats", "var") importFrom("utils", "data") to your NAMESPACE file.